### PR TITLE
Update manual query to get project from `gcp_project` table, instead of `gcp_iam_policy`

### DIFF
--- a/query/iam/iam_service_account_user_managed_external_key_rotation_period.sql
+++ b/query/iam/iam_service_account_user_managed_external_key_rotation_period.sql
@@ -5,11 +5,9 @@ select
     when valid_after_time <= (current_date - interval '90' day) then 'alarm'
     else 'ok'
   end status,
-  case
-    when valid_after_time <= (current_date - interval '90' day)
-      then service_account_name || name || ' created ' || to_char(valid_after_time , 'DD-Mon-YYYY') ||
+  service_account_name || name || ' created ' || to_char(valid_after_time , 'DD-Mon-YYYY') ||
     ' (' || extract(day from current_timestamp - valid_after_time) || ' days).'
-  end reason,
+  as reason,
   -- Additional Dimensions
   project
 from

--- a/query/logging/logging_metric_alert_audit_configuration_changes.sql
+++ b/query/logging/logging_metric_alert_audit_configuration_changes.sql
@@ -12,7 +12,7 @@ with filter_data as (
 )
 select
   -- Required Columns
-  project_id resource,
+  'https://cloudresourcemanager.googleapis.com/v1/projects/' || project_id resource,
   case
     when (select count(metric_name) from filter_data) > 0 then 'ok'
     else 'alarm'

--- a/query/logging/logging_metric_alert_audit_configuration_changes.sql
+++ b/query/logging/logging_metric_alert_audit_configuration_changes.sql
@@ -12,7 +12,7 @@ with filter_data as (
 )
 select
   -- Required Columns
-  project resource,
+  project_id resource,
   case
     when (select count(metric_name) from filter_data) > 0 then 'ok'
     else 'alarm'
@@ -23,6 +23,6 @@ select
     else 'Log metric and alert do not exist for audit configuration changes.'
   end reason,
   -- Additional Dimensions
-  project
+  project_id
 from
-  gcp_iam_policy;
+  gcp_project;

--- a/query/logging/logging_metric_alert_custom_role_changes.sql
+++ b/query/logging/logging_metric_alert_custom_role_changes.sql
@@ -12,7 +12,7 @@ with filter_data as (
 )
 select
   -- Required Columns
-  project_id resource,
+  'https://cloudresourcemanager.googleapis.com/v1/projects/' || project_id resource,
   case
     when (select count(metric_name) from filter_data) > 0 then 'ok'
     else 'alarm'

--- a/query/logging/logging_metric_alert_custom_role_changes.sql
+++ b/query/logging/logging_metric_alert_custom_role_changes.sql
@@ -12,7 +12,7 @@ with filter_data as (
 )
 select
   -- Required Columns
-  project resource,
+  project_id resource,
   case
     when (select count(metric_name) from filter_data) > 0 then 'ok'
     else 'alarm'
@@ -23,6 +23,6 @@ select
     else 'Log metric and alert do not exist for custom role changes.'
   end reason,
   -- Additional Dimensions
-  project
+  project_id
 from
-  gcp_iam_policy;
+  gcp_project;

--- a/query/logging/logging_metric_alert_firewall_rule_changes.sql
+++ b/query/logging/logging_metric_alert_firewall_rule_changes.sql
@@ -12,7 +12,7 @@ with filter_data as (
 )
 select
   -- Required Columns
-  project_id resource,
+  'https://cloudresourcemanager.googleapis.com/v1/projects/' || project_id resource,
   case
     when (select count(metric_name) from filter_data) > 0 then 'ok'
     else 'alarm'

--- a/query/logging/logging_metric_alert_firewall_rule_changes.sql
+++ b/query/logging/logging_metric_alert_firewall_rule_changes.sql
@@ -12,7 +12,7 @@ with filter_data as (
 )
 select
   -- Required Columns
-  project resource,
+  project_id resource,
   case
     when (select count(metric_name) from filter_data) > 0 then 'ok'
     else 'alarm'
@@ -23,6 +23,6 @@ select
     else 'Log metric and alert do not exist network for firewall rule changes.'
   end reason,
   -- Additional Dimensions
-  project
+  project_id
 from
-  gcp_iam_policy;
+  gcp_project;

--- a/query/logging/logging_metric_alert_network_changes.sql
+++ b/query/logging/logging_metric_alert_network_changes.sql
@@ -12,7 +12,7 @@ with filter_data as (
 )
 select
   -- Required Columns
-  project_id resource,
+  'https://cloudresourcemanager.googleapis.com/v1/projects/' || project_id resource,
   case
     when (select count(metric_name) from filter_data) > 0 then 'ok'
     else 'alarm'

--- a/query/logging/logging_metric_alert_network_changes.sql
+++ b/query/logging/logging_metric_alert_network_changes.sql
@@ -12,7 +12,7 @@ with filter_data as (
 )
 select
   -- Required Columns
-  project resource,
+  project_id resource,
   case
     when (select count(metric_name) from filter_data) > 0 then 'ok'
     else 'alarm'
@@ -23,6 +23,6 @@ select
     else 'Log metric and alert do not exist for network changes.'
   end reason,
   -- Additional Dimensions
-  project
+  project_id
 from
-  gcp_iam_policy;
+  gcp_project;

--- a/query/logging/logging_metric_alert_network_route_changes.sql
+++ b/query/logging/logging_metric_alert_network_route_changes.sql
@@ -12,7 +12,7 @@ with filter_data as (
 )
 select
   -- Required Columns
-  project_id resource,
+  'https://cloudresourcemanager.googleapis.com/v1/projects/' || project_id resource,
   case
     when (select count(metric_name) from filter_data) > 0 then 'ok'
     else 'alarm'

--- a/query/logging/logging_metric_alert_network_route_changes.sql
+++ b/query/logging/logging_metric_alert_network_route_changes.sql
@@ -12,7 +12,7 @@ with filter_data as (
 )
 select
   -- Required Columns
-  project resource,
+  project_id resource,
   case
     when (select count(metric_name) from filter_data) > 0 then 'ok'
     else 'alarm'
@@ -23,6 +23,6 @@ select
     else 'Log metric and alert do not exist for network route changes.'
   end reason,
   -- Additional Dimensions
-  project
+  project_id
 from
-  gcp_iam_policy;
+  gcp_project;

--- a/query/logging/logging_metric_alert_project_ownership_assignment.sql
+++ b/query/logging/logging_metric_alert_project_ownership_assignment.sql
@@ -12,7 +12,7 @@ with filter_data as (
 )
 select
   -- Required Columns
-  project_id resource,
+  'https://cloudresourcemanager.googleapis.com/v1/projects/' || project_id resource,
   case
     when (select count(metric_name) from filter_data) > 0 then 'ok'
     else 'alarm'

--- a/query/logging/logging_metric_alert_project_ownership_assignment.sql
+++ b/query/logging/logging_metric_alert_project_ownership_assignment.sql
@@ -12,7 +12,7 @@ with filter_data as (
 )
 select
   -- Required Columns
-  project resource,
+  project_id resource,
   case
     when (select count(metric_name) from filter_data) > 0 then 'ok'
     else 'alarm'
@@ -23,6 +23,6 @@ select
     else 'Log metric and alert do not exist exist for project ownership assignments/changes.'
   end reason,
   -- Additional Dimensions
-  project
+  project_id
 from
-  gcp_iam_policy;
+  gcp_project;

--- a/query/logging/logging_metric_alert_sql_instance_configuration_changes.sql
+++ b/query/logging/logging_metric_alert_sql_instance_configuration_changes.sql
@@ -12,7 +12,7 @@ with filter_data as (
 )
 select
   -- Required Columns
-  project_id resource,
+  'https://cloudresourcemanager.googleapis.com/v1/projects/' || project_id resource,
   case
     when (select count(metric_name) from filter_data) > 0 then 'ok'
     else 'alarm'

--- a/query/logging/logging_metric_alert_sql_instance_configuration_changes.sql
+++ b/query/logging/logging_metric_alert_sql_instance_configuration_changes.sql
@@ -12,7 +12,7 @@ with filter_data as (
 )
 select
   -- Required Columns
-  project resource,
+  project_id resource,
   case
     when (select count(metric_name) from filter_data) > 0 then 'ok'
     else 'alarm'
@@ -23,6 +23,6 @@ select
     else 'Log metric and alert do not exist for SQL instance configuration changes.'
   end reason,
   -- Additional Dimensions
-  project
+  project_id
 from
-  gcp_iam_policy;
+  gcp_project;

--- a/query/logging/logging_metric_alert_storage_iam_permission_changes.sql
+++ b/query/logging/logging_metric_alert_storage_iam_permission_changes.sql
@@ -12,7 +12,7 @@ with filter_data as (
 )
 select
   -- Required Columns
-  project_id resource,
+  'https://cloudresourcemanager.googleapis.com/v1/projects/' || project_id resource,
   case
     when (select count(metric_name) from filter_data) > 0 then 'ok'
     else 'alarm'

--- a/query/logging/logging_metric_alert_storage_iam_permission_changes.sql
+++ b/query/logging/logging_metric_alert_storage_iam_permission_changes.sql
@@ -12,7 +12,7 @@ with filter_data as (
 )
 select
   -- Required Columns
-  project resource,
+  project_id resource,
   case
     when (select count(metric_name) from filter_data) > 0 then 'ok'
     else 'alarm'
@@ -23,6 +23,6 @@ select
     else 'Log metric and alert do not exist for Storage IAM permission changes.'
   end reason,
   -- Additional Dimensions
-  project
+  project_id
 from
-  gcp_iam_policy;
+  gcp_project;

--- a/query/logging/logging_sink_configured_for_all_resource.sql
+++ b/query/logging/logging_sink_configured_for_all_resource.sql
@@ -21,7 +21,7 @@ select
     else 'Sinks not configured for all log entries.'
   end reason,
   -- Additional Dimensions
-  p.project as project
+  p.project_id as project
 from
-  gcp_iam_policy p
-  left join project_sink_count s on split_part(s.gcp_project, ',', 1) = p.project;
+  gcp_project p
+  left join project_sink_count s on split_part(s.gcp_project, ',', 1) = p.project_id;

--- a/query/manual_control.sql
+++ b/query/manual_control.sql
@@ -1,9 +1,9 @@
 select
   -- Required Columns
-  'https://cloudresourcemanager.googleapis.com/v1/projects/' || project as resource,
-  'info' as status,
-  'This is a manual control, you must verify compliance manually.' as reason,
+  'https://cloudresourcemanager.googleapis.com/v1/projects/' || project_id resource,
+  'info' status,
+  'This is a manual control, you must verify compliance manually.' reason,
   -- Additional Dimensions
-  project
+  project_id
 from
-  gcp_iam_policy;
+  gcp_project;


### PR DESCRIPTION
_Bug Fixes_
  - Fixed `reason` statement for CIS `Section 1.7`.

_Update_
  - Updated `manual-query.sql` and other queries related to `logging` to use `gcp_project` table, instead of `gcp_iam_policy`.