### PR TITLE
Fix kubernetes_cluster_private_cluster_config_enabled query to correctly check for public clusters closes #202

### DIFF
--- a/policy_bundle/kubernetes.pp
+++ b/policy_bundle/kubernetes.pp
@@ -324,19 +324,19 @@ control "kubernetes_cluster_subnetwork_private_ip_google_access_enabled" {
 query "kubernetes_cluster_private_cluster_config_enabled" {
   sql = <<-EOQ
     select
-    self_link resource,
-    case
-      when private_cluster_config is null then 'alarm'
-      else 'ok'
-    end as status,
-    case
-      when private_cluster_config is null then title || ' private cluster config disabled.'
-      else title || ' private cluster config enabled.'
-    end as reason
-    ${local.tag_dimensions_sql}
-    ${local.common_dimensions_sql}
-  from
-    gcp_kubernetes_cluster;
+      self_link resource,
+      case
+        when private_cluster_config ->> 'enablePrivateEndpoint' = 'true' then 'ok'
+        else 'alarm'
+      end as status,
+      case
+        when private_cluster_config ->> 'enablePrivateEndpoint' = 'true' then title || ' is not publicly accessible.'
+        else title || ' is publicly accessible.'
+      end as reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      gcp_kubernetes_cluster;
   EOQ
 }
 

--- a/policy_bundle/kubernetes.pp
+++ b/policy_bundle/kubernetes.pp
@@ -326,11 +326,11 @@ query "kubernetes_cluster_private_cluster_config_enabled" {
     select
       self_link resource,
       case
-        when private_cluster_config ->> 'enablePrivateEndpoint' = 'true' then 'ok'
+        when (private_cluster_config -> 'enablePrivateEndpoint')::bool then 'ok'
         else 'alarm'
       end as status,
       case
-        when private_cluster_config ->> 'enablePrivateEndpoint' = 'true' then title || ' is not publicly accessible.'
+        when (private_cluster_config -> 'enablePrivateEndpoint')::bool then title || ' is not publicly accessible.'
         else title || ' is publicly accessible.'
       end as reason
       ${local.tag_dimensions_sql}


### PR DESCRIPTION
```
select  self_link resource,
      case
        when private_cluster_config ->> 'enablePrivateEndpoint' = 'true' then 'ok'
        else 'alarm'
      end as status,
      case
        when private_cluster_config ->> 'enablePrivateEndpoint' = 'true' then title || ' is not publicly accessible.'
        else title || ' is publicly accessible.'
      end as reason  from
      gcp_kubernetes_cluster;
+--------------------------------------------------------------------------------------------------+--------+---------------------------------------+
| resource                                                                                         | status | reason                                |
+--------------------------------------------------------------------------------------------------+--------+---------------------------------------+
| https://container.googleapis.com/v1/projects/nagraj-aaa/locations/us-central1/clusters/cluster-1 | ok     | cluster-1 is not publicly accessible. |
| https://container.googleapis.com/v1/projects/nagraj-aaa/locations/us-central1/clusters/cluster-2 | alarm  | cluster-2 is publicly accessible.     |
+--------------------------------------------------------------------------------------------------+--------+---------------------------------------+```
