### PR TITLE
Queries for metadata are case sensitive, while GCP is not case sensitive, leading to inaccurate control results. closes #213

### DIFF
--- a/policy_bundle/project.pp
+++ b/policy_bundle/project.pp
@@ -155,11 +155,21 @@ query "project_oslogin_enabled" {
     select
       id resource,
       case
-        when common_instance_metadata -> 'items' @> '[{"key":"enable-oslogin","value":"TRUE"}]' then 'ok'
+        when exists (
+          select 1
+          from jsonb_array_elements(common_instance_metadata -> 'items') as items
+          where items ->> 'key' = 'enable-oslogin'
+            and lower(items ->> 'value') = 'true'
+        ) then 'ok'
         else 'alarm'
       end as status,
       case
-        when common_instance_metadata -> 'items' @> '[{"key":"enable-oslogin","value":"TRUE"}]' then title || ' OS login enabled.'
+        when exists (
+          select 1
+          from jsonb_array_elements(common_instance_metadata -> 'items') as items
+          where items ->> 'key' = 'enable-oslogin'
+            and lower(items ->> 'value') = 'true'
+        ) then title || ' OS login enabled.'
         else title || ' OS login disabled.'
       end as reason
       ${local.common_dimensions_sql}

--- a/policy_bundle/project.pp
+++ b/policy_bundle/project.pp
@@ -153,13 +153,13 @@ query "project_service_container_scanning_api_enabled" {
 query "project_oslogin_enabled" {
   sql = <<-EOQ
     select
-      id resource,
+      id as resource,
       case
         when exists (
           select 1
           from jsonb_array_elements(common_instance_metadata -> 'items') as items
-          where items ->> 'key' = 'enable-oslogin'
-            and lower(items ->> 'value') = 'true'
+          where lower(items ->> 'key') = 'enable-oslogin'
+            and lower(items ->> 'value') in ('true','y','yes','1')
         ) then 'ok'
         else 'alarm'
       end as status,
@@ -167,8 +167,8 @@ query "project_oslogin_enabled" {
         when exists (
           select 1
           from jsonb_array_elements(common_instance_metadata -> 'items') as items
-          where items ->> 'key' = 'enable-oslogin'
-            and lower(items ->> 'value') = 'true'
+          where lower(items ->> 'key') = 'enable-oslogin'
+            and lower(items ->> 'value') in ('true','y','yes','1')
         ) then title || ' OS login enabled.'
         else title || ' OS login disabled.'
       end as reason


### PR DESCRIPTION
```
> select
      id as resource,
      case
        when exists (
          select 1
          from jsonb_array_elements(common_instance_metadata -> 'items') as items
          where lower(items ->> 'key') = 'enable-oslogin'
            and lower(items ->> 'value') in ('true','y','yes','1')
        ) then 'ok'
        else 'alarm'
      end as status,
      case
        when exists (
          select 1
          from jsonb_array_elements(common_instance_metadata -> 'items') as items
          where lower(items ->> 'key') = 'enable-oslogin'
            and lower(items ->> 'value') in ('true','y','yes','1')
        ) then title || ' OS login enabled.'
        else title || ' OS login disabled.'
      end as reason
    from
      gcp_compute_project_metadata;
+---------------------+--------+-------------------------------+
| resource            | status | reason                        |
+---------------------+--------+-------------------------------+
| 123457899077900 | alarm  | nagraj-aaa OS login disabled. |
+---------------------+--------+-------------------------------+



with project_metadata as (
      select
        m.project,
        coalesce(
          (
            select lower(item ->> 'value')
            from jsonb_array_elements(m.common_instance_metadata -> 'items') as item
            where lower(item ->> 'key') = 'enable-oslogin'
            limit 1
          ), ''
        ) as project_oslogin
      from
        gcp_compute_project_metadata m
    ), instance_metadata as (
      select
        i.self_link,
        i.title,
        i.project,
        i.tags,
        i.location,
        i._ctx,
        coalesce(
          (
            select lower(item ->> 'value')
            from jsonb_array_elements(i.metadata -> 'items') as item
            where lower(item ->> 'key') = 'enable-oslogin'
            limit 1
          ), ''
        ) as instance_oslogin
      from
        gcp_compute_instance i
    )
  select
    i.self_link as resource,
    case
      when pm.project_oslogin = '' then 'alarm'
      when pm.project_oslogin in ('false', 'n', 'no', '0') then 'alarm'
      when pm.project_oslogin in ('true', 'y', 'yes', '1')
          and i.instance_oslogin in ('false', 'n', 'no', '0') then 'alarm'
      else 'ok'
    end as status,
    case
      when pm.project_oslogin = '' then i.title || ' has OS login disabled at project level.'
      when pm.project_oslogin in ('false', 'n', 'no', '0') then i.title || ' has OS login disabled at project level.'
      when pm.project_oslogin in ('true', 'y', 'yes', '1') and i.instance_oslogin in ('false', 'n', 'no', '0') then i.title || ' OS login setting is disabled at instance level.'
      when pm.project_oslogin in ('true', 'y', 'yes', '1') and i.instance_oslogin = '' then i.title || ' inherits OS login enabled setting from project level.'
      else i.title || ' OS login enabled.'
    end as reason
  from
    instance_metadata i
    left join project_metadata pm on pm.project = i.project;
+------------------------------------------------------------------------------------------------------------------+--------+------------------------------------------------------------------+
| resource                                                                                                         | status | reason                                                           |
+------------------------------------------------------------------------------------------------------------------+--------+------------------------------------------------------------------+
| https://www.googleapis.com/compute/v1/projects/nagraj-aaa/zones/us-central1-b/instances/instance-25677777-081240 | alarm  | instance-25677777-081240 has OS login disabled at project level. |
+------------------------------------------------------------------------------------------------------------------+--------+------------------------------------------------------------------+
```

### Checklist
- [ ] Issue(s) linked
