### PR TITLE
fix: views in bigquery tables can't have encryption keys

### DIFF
--- a/policy_bundle/bigquery.pp
+++ b/policy_bundle/bigquery.pp
@@ -188,6 +188,8 @@ query "bigquery_table_encrypted_with_cmk" {
       ${local.tag_dimensions_sql}
       ${local.common_dimensions_sql}
     from
-      gcp_bigquery_table;
+      gcp_bigquery_table
+    where
+      type != 'VIEW';
   EOQ
 }


### PR DESCRIPTION
For #223 

Query bigquery_table_encrypted_with_cmk returns error for views, but since views can't have encryption key, we need to exclude view from query.

Thanks ! 

### Checklist
- [x] Issue(s) linked
